### PR TITLE
Fix type union for compatability with python <3.10

### DIFF
--- a/panama/run.py
+++ b/panama/run.py
@@ -89,7 +89,7 @@ INT_OR_DICT = IntOrDictParamType()
 def run(
     template: Path,
     events: int,
-    primary: int | dict,
+    primary: "int | dict",
     output: Path,
     jobs: int,
     corsika: Path,


### PR DESCRIPTION
Execution of panama on Python 3.8 leads to the error

```
$ panama
Traceback (most recent call last):
  File "/xxx/panama", line 5, in <module>
    from panama.cli import cli
  File "xxx/panama/cli.py", line 6, in <module>
    from .run import run
  File "/xxx/panama/run.py", line 92, in <module>
    primary: int | dict,
TypeError: unsupported operand type(s) for |: 'type' and 'type'
```

This should be the same issue as [here](https://github.com/tiangolo/typer/issues/371)

This is one possible fix for this to ensure compatibility with python versions older than 3.10