### PR TITLE
Modularize definition of prompt

### DIFF
--- a/panama/prompt.py
+++ b/panama/prompt.py
@@ -4,6 +4,7 @@ from particle import Particle
 
 D0_LIFETIME = Particle.from_name("D0").lifetime
 
+
 def is_prompt_lifetime_limit(
     df_particles: pd.DataFrame, lifetime_limit_ns: float = D0_LIFETIME * 10
 ) -> np.ndarray:
@@ -20,16 +21,18 @@ def is_prompt_lifetime_limit(
     A numpy boolean array, True for prompt, False for conventional
     """
 
-    dif = (
-        df_particles["hadron_gen"].to_numpy(copy=False)
-        - df_particles["mother_hadr_gen"].to_numpy(copy=False)
-    )
+    dif = df_particles["hadron_gen"].to_numpy(copy=False) - df_particles[
+        "mother_hadr_gen"
+    ].to_numpy(copy=False)
 
     return df_particles["has_mother"].to_numpy(copy=False) & (
         (
             (df_particles["mother_lifetimes"].to_numpy(copy=False) <= lifetime_limit_ns)
             & (
-                (np.abs(dif) <= 1 & ~df_particles["mother_is_resonance"].to_numpy(copy=False))
+                (
+                    np.abs(dif)
+                    <= 1 & ~df_particles["mother_is_resonance"].to_numpy(copy=False)
+                )
                 # np.abs because of some very weird stuff going on in ehist
                 | ((dif == 30) & df_particles["mother_has_charm"].to_numpy(copy=False))
             )

--- a/panama/prompt.py
+++ b/panama/prompt.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pandas as pd
+
+
+def is_prompt_lifetime_limit(
+    df_particles: pd.Dataframe, lifetime_limit_ns: float = D0_LIFETIME * 10
+) -> np.ndarray:
+    """Return a numpy array of prompt labels for the input dataframe differentiating it by the lifetime of the mother particle.
+
+    Parameters
+    ----------
+    df_particles: dataframe with the corsika particles, additional_columns have to be present when running `read_DAT`
+    lifetime_limit_ns:
+        The lifetime limit in nanoseconds above which a particle is considered conventional.
+
+    Returns
+    -------
+    A numpy boolean array, True for prompt, False for conventional
+    """
+
+    return df_particles["has_mother"].values & (
+        (
+            (mother_lifetimes.values <= lifetime_limit)
+            & (
+                (np.abs(dif) <= 1 & ~mother_is_resonance)
+                # np.abs because of some very weird stuff going on in ehist
+                | ((dif == 30) & mother_has_charm.values)
+            )
+        )
+        | (
+            (df_particles["mother_pdgid"].abs().values == 13)
+            & (df_particles["hadron_gen"] < 3)
+        )  # mother is muon (and in early generation)
+    )

--- a/panama/read.py
+++ b/panama/read.py
@@ -339,30 +339,30 @@ def read_DAT(
             grandmother_index[0] = df_particles.shape[0] - 1
 
             df_particles["has_mother"] = (
-                df_particles["is_mother"].iloc[mother_index].values
-                & df_particles["is_mother"].iloc[grandmother_index].values
+                df_particles["is_mother"].iloc[mother_index].to_numpy(copy=False)
+                & df_particles["is_mother"].iloc[grandmother_index].to_numpy(copy=False)
             )
 
             df_particles["mother_pdgid"] = (
-                df_particles["pdgid"].iloc[mother_index].values
+                df_particles["pdgid"].iloc[mother_index].to_numpy(copy=False)
             )
             df_particles.loc[
-                ~df_particles["has_mother"].values, "mother_pdgid"
+                ~df_particles["has_mother"].array, "mother_pdgid"
             ] = pdg_error_val
 
             df_particles["mother_corsikaid"] = (
-                df_particles["corsikaid"].iloc[mother_index].values
+                df_particles["corsikaid"].iloc[mother_index].array
             )
             df_particles.loc[
-                ~df_particles["has_mother"].values, "mother_corsikaid"
+                ~df_particles["has_mother"].array, "mother_corsikaid"
             ] = pdg_error_val
 
             df_particles["mother_hadr_gen"] = (
-                np.abs(df_particles["particle_description"].iloc[mother_index].values)
+                np.abs(df_particles["particle_description"].iloc[mother_index].array)
                 % 100
             )
             df_particles.loc[
-                ~df_particles["has_mother"].values, "mother_hadr_gen"
+                ~df_particles["has_mother"].array, "mother_hadr_gen"
             ] = pd.NA
 
             has_charm = {
@@ -403,14 +403,14 @@ def read_DAT(
             df_particles["mother_has_charm"] = mother_has_charm.values
 
             dif = (
-                df_particles["hadron_gen"].values
-                - df_particles["mother_hadr_gen"].values
+                df_particles["hadron_gen"].to_numpy(copy=False)
+                - df_particles["mother_hadr_gen"].to_numpy(copy=False)
             )
 
             is_pion_decay = (dif == 51) & (
-                (df_particles["mother_pdgid"].values == 111)
-                | (df_particles["mother_pdgid"].values == 211)
-                | (df_particles["mother_pdgid"].values == -211)
+                (df_particles["mother_pdgid"].to_numpy(copy=False) == 111)
+                | (df_particles["mother_pdgid"].to_numpy(copy=False) == 211)
+                | (df_particles["mother_pdgid"].to_numpy(copy=False) == -211)
             )
 
             df_particles["cleaned_mother_pdgid"] = df_particles["mother_pdgid"]
@@ -427,13 +427,13 @@ def read_DAT(
 
     if drop_mothers:
         df_particles.drop(
-            index=df_particles.query("particle_description < 0").index.values,
+            index=df_particles.query("particle_description < 0").index.array,
             inplace=True,
         )
 
     if drop_non_particles:
         df_particles.drop(
-            index=df_particles.query("pdgid == 0").index.values, inplace=True
+            index=df_particles.query("pdgid == 0").index.array, inplace=True
         )
 
     df_particles.set_index(


### PR DESCRIPTION
aim of this PR is to modularize the definition of what a "prompt particle" is exactly.
Different definitions can now be used in via `panama.prompt`. 
Other updates:
- use `.array` or `.to_numpy(copy=False)` instead of deprecated `.values`
- add parameter to redefine `pdg_error_val` (maybe this should be a hard-coded variable... unsure...)
- add `mother_pdgid_cleaned` to dataframe. This is to give a cleaned version of a pdgid equal to what icetray does