### PR TITLE
fix version bug

### DIFF
--- a/panama/__init__.py
+++ b/panama/__init__.py
@@ -1,22 +1,10 @@
-from pathlib import Path
-
-import toml
-
 from .cli import cli
 from .constants import PDGID_ERROR_VAL
 from .read import read_DAT
 from .run import CorsikaRunner
 from .weights import add_weight_prompt, add_weight_prompt_per_event, get_weights
 
-
-def get_version() -> str:
-    path = Path(__file__).resolve().parents[1] / "pyproject.toml"
-    with open(path) as f:
-        config = toml.loads(f.read())
-    return config["tool"]["poetry"]["version"]
-
-
-__version__ = get_version()
+__version__ = "0.6.1"
 
 __all__ = (
     "read_DAT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "corsika-panama"
-version = "0.6.0"
+version = "0.6.1"
 description = "PANdas And Multicore utils for corsikA7"
 authors = ["Ludwig Neste <ludwig.neste@tu-dortmund.de>"]
 license = "MIT"


### PR DESCRIPTION
As it turns out, `poetry` does not really support dynamic versioning out-of-the-box and I flawlessly introduced a bug while setting the `__version__` variable in the last release.
This bug is only present when installed and downloaded via pip, so the tests didn't cover it...
This might also fix #29 