### PR TITLE
Fix #100 (wrong parsing of mothers' hadron generation counter)

### DIFF
--- a/panama/read.py
+++ b/panama/read.py
@@ -24,7 +24,7 @@ from .prompt import is_prompt_lifetime_limit
 
 
 def read_DAT(
-    files: Path | list[Path] | None = None,
+    files: Path | str | list[Path] | None = None,
     glob: str | None = None,
     max_events: int | None = None,
     run_header_features: list[str] | None = None,
@@ -123,8 +123,8 @@ def read_DAT(
     if glob is not None:
         basepath = Path(glob).parent
         files = list(basepath.glob(Path(glob).name))
-    elif isinstance(files, Path):
-        files = [files]
+    elif isinstance(files, Path | str):
+        files = [Path(files)]
 
     assert isinstance(files, list)
 

--- a/panama/read.py
+++ b/panama/read.py
@@ -123,7 +123,7 @@ def read_DAT(
     if glob is not None:
         basepath = Path(glob).parent
         files = list(basepath.glob(Path(glob).name))
-    elif isinstance(files, Path | str):
+    elif isinstance(files, (Path, str)):  # noqa: UP038
         files = [Path(files)]
 
     assert isinstance(files, list)

--- a/panama/read.py
+++ b/panama/read.py
@@ -359,7 +359,7 @@ def add_mother_columns(
 
     df_particles["mother_hadr_gen"] = (
         np.abs(df_particles["particle_description"].iloc[mother_index]) % 100
-    )
+    ).to_numpy(copy=False)
     df_particles.loc[~df_particles["has_mother"], "mother_hadr_gen"] = pd.NA
 
     # copy mother values to daughter columns so we can drop them later

--- a/panama/version.py
+++ b/panama/version.py
@@ -9,7 +9,7 @@ except ImportError:
 __distribution__ = pkgs["panama"][0] if "panama" in pkgs else "corsika-panama"
 
 # __version__ = version(__distribution__)
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 LOGO_TEMPLATE = r"""
 ,-.----.                           ,--.das     nd               ____ ulticore utils for corsik  7

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -90,6 +90,20 @@ def test_read_corsia_file(test_file_path=SINGLE_TEST_FILE):
     except AssertionError:
         pass
 
+def test_parsing(test_file_path=GLOB_TEST_FILE):
+    """This tests if the parsing of the actual values in the files work."""
+    df_run, df_event, df = panama.read_DAT(
+        glob=test_file_path, drop_non_particles=False, mother_columns=True
+    )
+
+    # just perform manual checking with looking at the files
+    p = df.loc[34, 1, 3]
+    assert p["pdgid"] == -13
+    assert p["hadron_gen"] == 57
+    assert p["n_obs_level"] == 1
+    assert p["mother_hadr_gen"] == 6
+    assert p["mother_pdgid"] == 211
+    assert p["grandmother_pdgid"] == 211
 
 # Do not turn the PyTables performance warning into an error
 @pytest.mark.filterwarnings("ignore::pandas.errors.PerformanceWarning")
@@ -136,6 +150,9 @@ def test_read_none():
     with pytest.raises(ValueError, match="can't both be not None"):
         df_run, df_event, df = panama.read_DAT(files = ["bla1", "bla2"], glob="bla*")
 
+# BIG note: The following two  tests pass, but due to issue #100, I have big
+# reason to believe these tests don't catch as many errors as I thought.
+# e.g.: If the prompt/conv tag is completely wrong, they still seem to pass.
 def test_spectral_index(tmp_path, test_file_path=GLOB_TEST_FILE):
     """Test if we can fit the muon spectral index, with the test dataset"""
 


### PR DESCRIPTION
- add test to catch bug from #100 
- allow `read_DAT` to parse filepath as `str`
- fix #100 
- bump version to 1.0.1